### PR TITLE
Better Implementation of user friendly breakpoints

### DIFF
--- a/src/objects/_grid.scss
+++ b/src/objects/_grid.scss
@@ -54,7 +54,7 @@
 
   @each $breakpoint in map-keys($breakpoints) {
     @include media-breakpoint-above($breakpoint) {
-      $breakpoint: prefix($breakpoint, "\\"+ $breakpoints-prefix);
+      $breakpoint: prefix(breakpoint-name($breakpoint), "\\"+ $breakpoints-prefix);
 
       // Grid child Auto width
       .is-auto#{$breakpoint} {
@@ -79,7 +79,7 @@
 
   @each $breakpoint in map-keys($breakpoints) {
     @include media-breakpoint-above($breakpoint, $breakpoints) {
-      $breakpoint: prefix($breakpoint, "\\"+ $breakpoints-prefix);
+      $breakpoint: prefix(breakpoint-name($breakpoint), "\\"+ $breakpoints-prefix);
 
       // removing last column because cannot offset a whole grid
       @for $i from 1 through ($grid-columns - 1) {

--- a/src/settings/breakpoints/_breakpoints.scss
+++ b/src/settings/breakpoints/_breakpoints.scss
@@ -4,20 +4,12 @@
 
 // Define the minimum dimensions at which your layout will change,
 // adapting to different screen sizes, for use in media queries.
-@if $breakpoints-short-else-readable { // if short breakpoints are preferred
-  $breakpoints: (
-    null:       0,
-    sm:         576px,
-    md:         768px,
-    lg:         992px,
-    xl:         1200px
-  ) !default !global;
-}@else{ // if user friendly and readable breakpoints are preferred
-  $breakpoints: (
-    null:          0,
-    mobile:        576px,
-    tablet:        768px,
-    desktop:       992px,
-    large:         1200px
-  ) !default !global;
-}
+$breakpoints: (
+  null: 0,
+  sm: 576px,
+  md: 768px,
+  lg: 992px,
+  xl: 1200px
+) !default;
+
+$breakpoints-readable: null mobile tablet desktop large !default;

--- a/src/tools/functions/_breakpoints.scss
+++ b/src/tools/functions/_breakpoints.scss
@@ -69,3 +69,31 @@
   $next-lower: breakpoint-lower($next, $breakpoint);
   @return $next-lower - .05;
 }
+
+//
+// breakpoint-name
+// return breakpoint name based on setting `breakpoints-short-else-readable`
+//
+// Required arguments:
+// {String} $breakpoint - name of the breakpoint
+// [optional] {Map} $breakpoints - breakpoints map
+//
+// Example of use:
+// $breakpoints: (xs: 0, sm: 576px, md: 768px, lg: 992px, xl: 1200px);
+// $breakpoints-readable: null mobile tablet desktop large;
+// $breakpoints-short-else-readable: true;
+// breakpoint-only(md) => desktop
+//
+@function breakpoint-name($breakpoint, $breakpoints: $breakpoints) {
+  $breakpoints-keys: map-has-key($breakpoints, $breakpoint);
+
+  @if $breakpoints-short-else-readable {
+    // if short breakpoints are preferred
+    @return $breakpoint;
+  } @else {
+    // if user friendly breakpoints are preferred
+    $breakpoints-keys: map-keys($breakpoints);
+    $breakpoints-index: index($breakpoints-keys, $breakpoint);
+    @return nth($breakpoints-readable, $breakpoints-index);
+  }
+}

--- a/src/tools/mixins/_generate-class.scss
+++ b/src/tools/mixins/_generate-class.scss
@@ -57,7 +57,7 @@
 }
 
 @mixin generate-inner-class($class, $infix-key, $infix-value, $breakpoint, $properties, $values) {
-  $breakpoint-suffix: prefix($breakpoint, "\\"+ $breakpoints-prefix);
+  $breakpoint-suffix: prefix(breakpoint-name($breakpoint), "\\"+ $breakpoints-prefix);
 
   @each $key, $value in $values {
     $key: prefix($key, "-");


### PR DESCRIPTION
use of function to get breakpoint name based on setting `breakpoints-short-else-readable`.

within the framwork short names are used but while adding breakpoints to classes , breakpoint-name() is called to convert the name